### PR TITLE
Move the go module name to github.com/metallb/metallb-operator

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: metallb.io
 layout: go.kubebuilder.io/v2.0.0
-repo: github.com/fedepaol/metallboperator
+repo: github.com/metallb/metallb-operator
 version: 3-alpha
 plugins:
   go.operator-sdk.io/v2.0.0: {}

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -27,9 +27,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	metallbv1alpha1 "github.com/fedepaol/metallboperator/api/v1alpha1"
-	"github.com/fedepaol/metallboperator/pkg/apply"
-	"github.com/fedepaol/metallboperator/pkg/render"
+	metallbv1alpha1 "github.com/metallb/metallb-operator/api/v1alpha1"
+	"github.com/metallb/metallb-operator/pkg/apply"
+	"github.com/metallb/metallb-operator/pkg/render"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
-	metallbv1alpha1 "github.com/fedepaol/metallboperator/api/v1alpha1"
+	metallbv1alpha1 "github.com/metallb/metallb-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fedepaol/metallboperator
+module github.com/metallb/metallb-operator
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	metallbv1alpha1 "github.com/fedepaol/metallboperator/api/v1alpha1"
-	"github.com/fedepaol/metallboperator/controllers"
+	metallbv1alpha1 "github.com/metallb/metallb-operator/api/v1alpha1"
+	"github.com/metallb/metallb-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
We are moving the operator to be part of the metallb org, so here we
rename the go module and the relative imports accordingly.

